### PR TITLE
Use a Sphinx theme based on Tyrian

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,13 +73,18 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'tyrian_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'sidebar' : 'right',
+    'navigationlinks_top' : 'none',
+    'navigationlinks_bottom' : 'long',
+    'navigationlinks_navbar' : 'none'
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 [testenv]
 deps =
 	sphinx
+	git+https://github.com/mmagorsc/tyrian_sphinx_theme/#egg=tyrian_sphinx_theme
 whitelist_externals =
 	make
 


### PR DESCRIPTION
A Sphinx theme based on Tyrian is used. The theme is automatically
installed and applied when using tox. If you are not using tox. please
refer to the documentaion of the theme for further installation
instructions.

Signed-off-by: Max Magorsch <max@magorsch.de>