### PR TITLE
Add PG identifiers to policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /_build/
 /.tox/
+/exts/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ SPHINXPROJ    = GentooPolicyGuide
 SOURCEDIR     = .
 BUILDDIR      = _build
 
-all: html
+all: html $(BUILDDIR)/html/combined.html
+
+$(BUILDDIR)/html/combined.html: singlehtml
+	cp $(BUILDDIR)/singlehtml/index.html $@
 
 .PHONY: all Makefile
 

--- a/conf.py
+++ b/conf.py
@@ -11,10 +11,10 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('exts'))
 
 
 # -- Project information -----------------------------------------------------
@@ -38,7 +38,10 @@ release = ''
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.todo']
+extensions = [
+    'policyident',
+    'sphinx.ext.todo',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/dependencies.rst
+++ b/dependencies.rst
@@ -6,6 +6,7 @@ Dependencies
 
 Optional runtime dependencies
 -----------------------------
+:PG: 0001
 :Source: QA
 :Reference: https://wiki.gentoo.org/index.php?title=Project:Quality_Assurance/Policies&oldid=104017#USE-Controlled_Optional_RDEPENDS
 :Reported: no
@@ -35,6 +36,7 @@ This is especially important for packages that take long time to build.
 
 =-dependencies with no revision
 -------------------------------
+:PG: 0002
 :Source: QA
 :Reported: by repoman and pkgcheck
 
@@ -67,6 +69,7 @@ Slot and subslot dependencies
 
 on (sub-)slotted packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+:PG: 0011
 :Source: QA
 :Reference: https://archives.gentoo.org/gentoo-portage-dev/message/9cae3a92412a007febe7ac0612d50f5f
 :Reported: by repoman and pkgcheck
@@ -100,6 +103,7 @@ means 'verified that any slot is acceptable'.
 
 special case: Qt packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+:PG: 0012
 :Source: Qt project
 :Reference: https://wiki.gentoo.org/wiki/Project:Qt/Policies#Dependencies
 :Reported: no
@@ -132,6 +136,7 @@ They point out the case of Qt packages as an example.
 
 Revision bumps on runtime dependency changes
 --------------------------------------------
+:PG: 0003
 :Source: Council
 :Reference: https://projects.gentoo.org/council/meeting-logs/20151011-summary.txt
 :Reported: no
@@ -175,6 +180,7 @@ USE dependencies
 
 on packages without the flag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:PG: 0021
 :Source: QA (inferred from PMS)
 :Reported: by pkgcheck
 

--- a/ebuild-format.rst
+++ b/ebuild-format.rst
@@ -8,6 +8,7 @@ Ebuild file format
 
 Coding style
 ------------
+:PG: 0101
 :Source: QA
 :Reported: partially via repoman and pkgcheck
 
@@ -32,6 +33,7 @@ the ebuild.
 
 Code must be contained within ebuild and eclasses
 -------------------------------------------------
+:PG: 0102
 :Source: QA
 :Reference: https://bugs.gentoo.org/612630
 :Reported: no
@@ -54,6 +56,7 @@ that possibility, including linting tools.
 
 HOMEPAGE must not contain variables
 -----------------------------------
+:PG: 0103
 :Source: QA
 :Reported: by pkgcheck, highlighted as error by gentoo-syntax
 
@@ -73,6 +76,7 @@ as reducing the usefulness of plain tools such as grep.
 
 SRC_URI must not refer to HOMEPAGE
 ----------------------------------
+:PG: 0104
 :Source: QA
 :Reported: by pkgcheck
 
@@ -92,6 +96,7 @@ index.
 
 KEYWORDS must be defined on a single line
 -----------------------------------------
+:PG: 0105
 :Source: QA
 :Reported: no
 

--- a/exts/policyident.py
+++ b/exts/policyident.py
@@ -1,0 +1,48 @@
+# Handle :PG: policy identifiers for Policy Guide
+# (c) 2020 Michał Górny
+# 2-clause BSD license
+
+from docutils import nodes
+
+from sphinx.util import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def find_pg_id(section):
+    # first child should be title
+    title = section.children[0]
+    assert isinstance(title, nodes.title)
+    # second child should be field list
+    cl = section.children[1]
+    if not isinstance(cl, nodes.field_list):
+        return None
+
+    for f in cl.traverse(nodes.field):
+        fn = next(iter(f.traverse(nodes.field_name)))
+        fv = next(iter(f.traverse(nodes.field_body)))
+        if fn.astext().upper() == 'PG':
+            if fn.astext() != 'PG':
+                raise RuntimeError('PG field must be uppercase')
+            iv = '{:04d}'.format(int(fv.astext(), 10))
+            if fv.astext() != iv:
+                raise RuntimeError('PG value must be 4 digits, zero-padded ({})'
+                                   .format(iv))
+            return iv
+
+    logger.warning('%s: no PG identifier found', title.astext())
+
+
+def on_doctree_read(app, doctree):
+    for node in doctree.traverse(nodes.section):
+        pg_id = find_pg_id(node)
+        if pg_id is not None:
+            node['ids'].insert(0, 'pg' + pg_id)
+
+
+def setup(app):
+    app.connect('doctree-read', on_doctree_read)
+    return {
+        'version': '0',
+    }

--- a/exts/policyident.py
+++ b/exts/policyident.py
@@ -7,6 +7,7 @@ import collections
 from docutils import nodes
 
 from sphinx.domains import Index
+from sphinx.environment.collectors.toctree import TocTreeCollector
 from sphinx.util import logging
 
 
@@ -14,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 Policy = collections.namedtuple('Policy', ('id', 'title', 'docname',
                                            'chapter'))
+
+toccollector = TocTreeCollector()
 
 
 class PolicyIndex(Index):
@@ -89,6 +92,9 @@ def on_doctree_read(app, doctree):
             node['ids'].insert(0, 'pg' + pg_id)
             env.policy_index.append(Policy(pg_id, title, env.docname,
                                            chapter))
+
+    # update the table of conents to use the 'pgXXXX' ids
+    toccollector.process_doc(app, doctree)
 
 
 def on_env_purge_doc(app, env, docname):

--- a/exts/policyident.py
+++ b/exts/policyident.py
@@ -2,12 +2,43 @@
 # (c) 2020 Michał Górny
 # 2-clause BSD license
 
+import collections
+
 from docutils import nodes
 
+from sphinx.domains import Index
 from sphinx.util import logging
 
 
 logger = logging.getLogger(__name__)
+
+Policy = collections.namedtuple('Policy', ('id', 'title', 'docname',
+                                           'chapter'))
+
+
+class PolicyIndex(Index):
+    name = 'policy-index'
+    localname = 'Policy Index'
+    shortname = 'Policy Index'
+
+    def generate(self, docnames=None):
+        env = self.domain.env
+        if not hasattr(env, 'policy_index'):
+            env.policy_index = []
+
+        entries = collections.defaultdict(list)
+        for p in env.policy_index:
+            if docnames is not None and p.docname not in docnames:
+                continue
+            entries[p.chapter].append(('PG' + p.id,  # name
+                                       0,            # subtype
+                                       p.docname,    # docname
+                                       'pg' + p.id,  # anchor
+                                       p.title,      # extra
+                                       '',           # qualifier
+                                       ''))          # descr
+
+        return ([(k, sorted(v)) for k, v in entries.items()], False)
 
 
 def find_pg_id(section):
@@ -17,7 +48,7 @@ def find_pg_id(section):
     # second child should be field list
     cl = section.children[1]
     if not isinstance(cl, nodes.field_list):
-        return None
+        return None, title.astext(), None
 
     for f in cl.traverse(nodes.field):
         fn = next(iter(f.traverse(nodes.field_name)))
@@ -29,20 +60,61 @@ def find_pg_id(section):
             if fv.astext() != iv:
                 raise RuntimeError('PG value must be 4 digits, zero-padded ({})'
                                    .format(iv))
-            return iv
+
+            el = section
+            titles = []
+            while el.parent is not None:
+                title = el.children[0]
+                assert isinstance(title, nodes.title)
+                titles.append(title.astext())
+                el = el.parent
+            # combine all section titles up to but excluding
+            # the chapter title
+            title = ': '.join(reversed(titles[:-1]))
+
+            return iv, title, titles[-1]
 
     logger.warning('%s: no PG identifier found', title.astext())
+    return None, title.astext(), None
 
 
 def on_doctree_read(app, doctree):
+    env = app.builder.env
+    if not hasattr(env, 'policy_index'):
+        env.policy_index = []
+
     for node in doctree.traverse(nodes.section):
-        pg_id = find_pg_id(node)
+        pg_id, title, chapter = find_pg_id(node)
         if pg_id is not None:
             node['ids'].insert(0, 'pg' + pg_id)
+            env.policy_index.append(Policy(pg_id, title, env.docname,
+                                           chapter))
+
+
+def on_env_purge_doc(app, env, docname):
+    if not hasattr(env, 'policy_index'):
+        return
+
+    env.policy_index = [p for p in env.policy_index
+                        if p.docname != docname]
+
+
+def on_env_merge_info(app, env, docnames, other):
+    if not hasattr(other, 'policy_index'):
+        return
+    if not hasattr(env, 'policy_index'):
+        env.policy_index = []
+
+    env.policy_index.extend(other.policy_index)
 
 
 def setup(app):
     app.connect('doctree-read', on_doctree_read)
+    app.connect('env-purge-doc', on_env_purge_doc)
+    app.connect('env-merge-info', on_env_merge_info)
+    app.add_index_to_domain('std', PolicyIndex)
     return {
         'version': '0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
     }

--- a/filesystem.rst
+++ b/filesystem.rst
@@ -5,6 +5,7 @@ File system layout
 
 Installation paths
 ------------------
+:PG: 0201
 :Source: QA
 :Reference: https://gitweb.gentoo.org/repo/gentoo.git/tree/metadata/install-qa-check.d/08gentoo-paths
 :Reported: via install-qa-check.d
@@ -60,6 +61,7 @@ exceptions are:
 
 Support for separate /usr
 -------------------------
+:PG: 0202
 :Source: QA
 :Reference: https://projects.gentoo.org/council/meeting-logs/20130813-summary.txt
             https://projects.gentoo.org/council/meeting-logs/20130924-summary.txt
@@ -79,6 +81,7 @@ from rootfs to initramfs.
 
 Strict multilib layout
 ----------------------
+:PG: 0203
 :Source: QA
 :Reference: https://gitweb.gentoo.org/proj/portage.git/tree/bin/install-qa-check.d/80multilib-strict
 :Reported: via install-qa-check.d, fatal
@@ -103,6 +106,7 @@ to be correctly found by the dynamic loader.
 
 Static libraries and libtool files
 ----------------------------------
+:PG: 0204
 :Source: QA
 :Reference: https://gitweb.gentoo.org/proj/portage.git/tree/bin/install-qa-check.d/80libraries
 :Reported: via install-qa-check.d, fatal
@@ -124,6 +128,7 @@ be a waste of space.
 
 Game install locations and ownership
 ------------------------------------
+:PG: 0205
 :Source: Council, clarified by QA
 :Reference: https://projects.gentoo.org/council/meeting-logs/20151213-summary.txt
             https://projects.gentoo.org/council/meeting-logs/20151011-summary.txt
@@ -160,6 +165,7 @@ fulfill that purpose.
 
 Absolute symbolic link targets
 ------------------------------
+:PG: 0206
 :Source: QA
 :Reported: by repoman and pkgcheck (when ebuild-generated)
 

--- a/installed-files.rst
+++ b/installed-files.rst
@@ -7,6 +7,7 @@ Installed files
 
 Installation of small files
 ---------------------------
+:PG: 0301
 :Source: QA
 :Reported: no
 
@@ -40,6 +41,7 @@ such a huge package in order to install one tiny file.
 
 Installation of static libraries
 --------------------------------
+:PG: 0302
 :Source: QA
 :Reported: no
 
@@ -61,6 +63,7 @@ libraries if they are never going to be used.
 
 Installation of libtool (.la) files
 -----------------------------------
+:PG: 0303
 :Source: QA
 :Reported: no
 

--- a/keywords.rst
+++ b/keywords.rst
@@ -5,6 +5,7 @@ Keywording and stabilization
 
 Rekeywording on dropped keywords
 --------------------------------
+:PG: 0401
 :Source: QA
 :Reported: by pkgcheck and repoman
 
@@ -23,6 +24,7 @@ a new version or to remove an old version.
 
 Stabilizing new versions
 ------------------------
+:PG: 0402
 :Source: QA
 :Reported: by pkgcheck
 
@@ -50,6 +52,7 @@ requested on remaining architectures in the first place.
 
 Removing stable keywords
 ------------------------
+:PG: 0403
 :Source: QA
 :Reference: https://wiki.gentoo.org/index.php?title=Project:Quality_Assurance/Policies&oldid=126033#Dropping_Stable_KEYWORDs
 :Reported: n/a

--- a/languages.rst
+++ b/languages.rst
@@ -13,6 +13,7 @@ Python
 
 Eclass usage
 ~~~~~~~~~~~~
+:PG: 0501
 :Source: Python project
 :Reference: https://wiki.gentoo.org/wiki/Project:Python/Eclasses
 :Reported: by pkgcheck
@@ -41,6 +42,7 @@ implementations with minimal changes to existing ebuilds.
 
 Python 2 deprecation
 ~~~~~~~~~~~~~~~~~~~~
+:PG: 0502
 :Source: Python project
 :Reference: https://wiki.gentoo.org/wiki/Project:Python#Python_2_end-of-life
 :Reported: no

--- a/maintainer.rst
+++ b/maintainer.rst
@@ -5,6 +5,7 @@ Package Maintainers
 
 Adding new maintainers
 ----------------------
+:PG: 0601
 :Source: QA
 :Reported: no
 
@@ -31,6 +32,7 @@ them from packages actually within project's profile was hard.
 
 New packages without a maintainer
 ---------------------------------
+:PG: 0602
 :Source: QA
 :Reported: no
 
@@ -50,6 +52,7 @@ to take care of them.
 
 Removing package maintainers
 ----------------------------
+:PG: 0603
 :Source: QA
 :Reported: no
 

--- a/other-metadata.rst
+++ b/other-metadata.rst
@@ -6,6 +6,7 @@ Other metadata variables
 
 Dynamic slots (multislot flag)
 ------------------------------
+:PG: 0701
 :Source: QA (inferred from PMS)
 :Reference: https://wiki.gentoo.org/index.php?title=Project:Quality_Assurance/Policies&oldid=109991#multislot.2FUSE-dependent_SLOT
 :Reported: ``use`` in global scope triggers fatal error
@@ -42,6 +43,7 @@ invalidation or explicit errors.
 
 HOMEPAGE value must be meaningful
 ---------------------------------
+:PG: 0702
 :Source: QA
 :Reference: https://archives.gentoo.org/gentoo-dev/message/83cc5bbd7bbe8bdf04dd3c3bc7f8a035
 :Reported: known bad values are reported by pkgcheck
@@ -69,6 +71,7 @@ easy to identify such packages.
 
 RESTRICT=test for USE=-test
 ---------------------------
+:PG: 0703
 :Source: QA
 :Reported: by pkgcheck
 
@@ -98,6 +101,7 @@ this circumstance, and they will not fail for users.
 
 LICENSE
 -------
+:PG: 0704
 :Source: QA
 :Reported: no
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ whitelist_externals =
 	make
 
 commands =
-	make {posargs:html}
+	make {posargs:all}

--- a/use-flags.rst
+++ b/use-flags.rst
@@ -8,6 +8,7 @@ USE flags
 
 Versioned USE flags
 -------------------
+:PG: 0801
 :Source: QA
 :Reference: https://wiki.gentoo.org/index.php?title=Project:Quality_Assurance/Policies&oldid=109991#Versioned_USE_flags
 :Reported: no
@@ -38,6 +39,7 @@ with the QA team before introduction.
 
 USE=gui flag
 ------------
+:PG: 0802
 :Source: QA
 :Reference: https://archives.gentoo.org/gentoo-dev/message/cf3f5a59ac918335766632bd02438722
 :Reported: no
@@ -61,6 +63,7 @@ multiple GUIs.
 
 Underscores in USE flag names
 -----------------------------
+:PG: 0803
 :Source: Council
 :Reference: https://projects.gentoo.org/council/meeting-logs/20191013-summary.txt
 :Reported: by pkgcheck

--- a/user-group.rst
+++ b/user-group.rst
@@ -6,6 +6,7 @@ Users and groups
 
 User and group account policy
 -----------------------------
+:PG: 0901
 :Source: QA
 :Reference: https://bugs.gentoo.org/702460
 :Reported: by repoman and pkgcheck (as deprecated eclass)


### PR DESCRIPTION
As discussed before, here's a PR adding numeric identifiers / permalinks for policies.

I went for PGnnnn scheme. Starting with 0001 for the first section, incrementing by 10 for subsections, 100 for chapters, so we have some space for related policies to have successive numbers.

Now every policy section needs to have a `:PG: nnnn` field. This causes `#pgNNNN` id to be added to the section, and the `¶` link near the section now defaults to it. For some reason, TOC still uses normal links (help welcome).

I've also added a 'Policy Index' that lists all policies in order.

singlehtml preview (this is more convenient for linking stuff):
https://dev.gentoo.org/~mgorny/tmp/pg-test/combined.html#pg0001
https://dev.gentoo.org/~mgorny/tmp/pg-test/combined.html#pg0303

split html preview:
https://dev.gentoo.org/~mgorny/tmp/pg-test/dependencies.html#pg0001
https://dev.gentoo.org/~mgorny/tmp/pg-test/installed-files.html#pg0303
https://dev.gentoo.org/~mgorny/tmp/pg-test/std-policy-index.html

TODO:
- [x] can we get 'Policy Index' to the top bar without having to hardcode it in the theme?
- [x] can we remove the duplicate from main TOC?
- [x] can we avoid hacky `policy-index.rst` and instead have it fully generated like `genindex`?
- [x] right-hand side TOC doesn't appear on policy-index page

CC @mmagorsc