### PR TITLE
deprecation: Include deprecated eclasses

### DIFF
--- a/deprecation.rst
+++ b/deprecation.rst
@@ -17,3 +17,21 @@ no version bumps are expected.
 
 The current list of deprecated EAPIs is stored as ``eapis-deprecated``
 in ``metadata/layout.conf``.
+
+
+.. index:: eclass; deprecated
+
+Deprecated eclasses
+-------------------
+:PG: 1003
+:Source: individual eclass maintainers
+:Reference: https://gitweb.gentoo.org/repo/gentoo.git/tree/metadata/qa-policy.conf
+:Reported: by pkgcheck and repoman
+
+Deprecated eclasses should not be used in new ebuilds.  Existing
+packages should be updated not to use these eclasses on version bumps,
+or proactively when no version bumps are expected.
+
+The current list of deprecated eclasses is stored along with suggested
+replacements as ``deprecated-eclass`` section
+of ``metadata/qa-policy.conf``.


### PR DESCRIPTION
Pretty much the boilerplate. The `qa-policy.conf` file is not yet pushed, I'll recheck the link once it is.