### PR TITLE
installed-files: Restrict find to regular files

### DIFF
--- a/installed-files.rst
+++ b/installed-files.rst
@@ -79,7 +79,7 @@ b. the package is installing static libraries that have additional
 
 It is recommended to use the following one-liner to remove .la files::
 
-    find "${ED}" -name '*.la' -delete || die
+    find "${ED}" -type f -name '*.la' -delete || die
 
 *Rationale*: libtool files were historically introduced as an attempt
 to supplement static library archives with dependent library list.


### PR DESCRIPTION
Rationale: libtool .la files are regular files, therefore find -type f
is more correct in this context.

Signed-off-by: Ulrich Müller <ulm@gentoo.org>